### PR TITLE
fix: fix Blender crash when importing materials from asset browser

### DIFF
--- a/src/blender-injection/BlenderObj.h
+++ b/src/blender-injection/BlenderObj.h
@@ -2,7 +2,7 @@
 
 // define memory layouts of Blender
 
-struct Context
+struct bContext
 {
     int thread;
 
@@ -22,8 +22,8 @@ struct Context
 
         struct PollMsgDyn_Params
         {
-            char* (*get_fn)(Context*, void*);
-            char* (*free_fn)(Context*, void*);
+            char* (*get_fn)(bContext*, void*);
+            char* (*free_fn)(bContext*, void*);
             void* user_data;
         } operator_poll_msg_dyn_params;
     } wm;
@@ -52,26 +52,10 @@ using ListBase = struct ListBase
 
 using wmDragActiveDropState = struct wmDragActiveDropState
 {
-    /** Informs which dropbox is activated with the drag item.
-     * When this value changes, the #draw_activate and #draw_deactivate dropbox callbacks are
-     * triggered.
-     */
     struct wmDropBox* active_dropbox;
-
-    /** If `active_dropbox` is set, the area it successfully polled in. To restore the context of it
-     * as needed. */
     struct ScrArea* area_from;
-    /** If `active_dropbox` is set, the region it successfully polled in. To restore the context of
-     * it as needed. */
     struct ARegion* region_from;
-
-    /** If `active_dropbox` is set, additional context provided by the active (i.e. hovered) button.
-     * Activated before context sensitive operations (polling, drawing, dropping). */
     struct bContextStore* ui_context;
-
-    /** Text to show when a dropbox poll succeeds (so the dropbox itself is available) but the
-     * operator poll fails. Typically the message the operator set with
-     * CTX_wm_operator_poll_msg_set(). */
     const char* disabled_info;
     bool free_disabled_info;
 };
@@ -79,24 +63,57 @@ using wmDragActiveDropState = struct wmDragActiveDropState
 using wmDrag = struct wmDrag
 {
     struct wmDrag *next, *prev;
-
     int icon;
-    /** See 'WM_DRAG_' defines above. */
     int type;
     void* poin;
-    char path[1024]; /* FILE_MAX */
+    char path[1024];
     double value;
-
-    /** If no icon but imbuf should be drawn around cursor. */
     struct ImBuf* imb;
     float imbuf_scale;
-
     wmDragActiveDropState drop_state;
-
     eWM_DragFlags flags;
-
-    /** List of wmDragIDs, all are guaranteed to have the same ID type. */
     ListBase ids;
-    /** List of `wmDragAssetListItem`s. */
     ListBase asset_items;
+};
+
+using wmTabletData = struct wmTabletData
+{
+    int active;
+    float pressure;
+    float x_tilt;
+    float y_tilt;
+    char is_motion_absolute;
+};
+
+using eWM_EventFlag = enum eWM_EventFlag
+{
+    WM_EVENT_SCROLL_INVERT = (1 << 0),
+    WM_EVENT_IS_REPEAT = (1 << 1),
+    WM_EVENT_FORCE_DRAG_THRESHOLD = (1 << 2),
+};
+
+using wmEvent = struct wmEvent
+{
+    struct wmEvent *next, *prev;
+    short type;
+    short val;
+    int xy[2];
+    int mval[2];
+    char utf8_buf[6];
+    uint8_t modifier;
+    int8_t direction;
+    short keymodifier;
+    wmTabletData tablet;
+    eWM_EventFlag flag;
+    short custom;
+    short customdata_free;
+    void* customdata;
+    short prev_type;
+    short prev_val;
+    int prev_xy[2];
+    short prev_press_type;
+    int prev_press_xy[2];
+    uint8_t prev_press_modifier;
+    short prev_press_keymodifier;
+    double prev_press_time;
 };

--- a/src/blender-injection/extern.cpp
+++ b/src/blender-injection/extern.cpp
@@ -21,44 +21,46 @@ const std::vector<std::string> SUPPORTED_FORMATS = {
     ".wrl"
 };
 
-std::unordered_map<std::uintptr_t, bool> onFired = {};
+std::vector<std::intptr_t> isAlreadyTriggered = {};
 
 extern "C" void DropEventHookCallback(void* c, void* win, char* path)
 {
     std::cout << "f:" << path << std::endl;
 }
 
-extern "C" bool View3DImaEmptyDropPollHookCallback(void* c, wmDrag* drag, void* event)
+extern "C" bool View3DImaEmptyDropPollHookCallback(bContext* c, wmDrag* drag, wmEvent* event)
 {
-    const std::filesystem::path path(drag->path);
-    const auto extension = path.extension();
+    const auto ptr = reinterpret_cast<intptr_t>(drag);
+    if (const auto itr = std::ranges::find(isAlreadyTriggered, ptr); itr != std::end(isAlreadyTriggered))
+        return false; // already triggered
 
-    const auto ref = std::ranges::find(SUPPORTED_FORMATS, extension);
-    if (ref != std::end(SUPPORTED_FORMATS))
+    isAlreadyTriggered.push_back(ptr);
+
+    if (drag->type == /* WM_DRAG_PATH */ 4)
     {
-        const auto ptr = reinterpret_cast<std::intptr_t>(drag);
-        if (onFired.contains(ptr))
+        const std::filesystem::path path(drag->path);
+        const auto extension = path.extension();
+
+        if (const auto ref = std::ranges::find(SUPPORTED_FORMATS, extension); ref != std::end(SUPPORTED_FORMATS))
         {
-            return false;
+            const char* imports[] = {"bpy", nullptr};
+            const auto expression = R"(bpy.ops.object.drop_event_listener2("INVOKE_DEFAULT", filename=R")" + std::string(drag->path) + "\")";
+
+            BlenderPatcher::GetInstance()->RunStringEval(c, imports, expression.c_str());
+            return false; // already triggered
         }
-
-        onFired[ptr] = true;
-
-        const char* imports[] = {"bpy", nullptr};
-        const auto expression = R"(bpy.ops.object.drop_event_listener2("INVOKE_DEFAULT", filename=R")" + std::string(drag->path) + "\")";
-
-        BlenderPatcher::GetInstance()->RunStringEval(c, imports, expression.c_str());
     }
 
+    if (!BlenderPatcher::GetInstance()->View3DImaDropPoll(c, drag, event))
+        return false;
+
+    auto ob = static_cast<int*>(BlenderPatcher::GetInstance()->EDView3dGiveObjectUnderCursor(c, event->mval));
+    if (ob == nullptr)
+        return true;
+
+    // NOTE: the pointed fields (value) have been determined, this cast is no problem.
+    if (reinterpret_cast<int>(ob + 0x000000E0) == /* OB_EMPTY */ 0 && reinterpret_cast<int>(ob + 0x000003FF) == /* OB_EMPTY_IMAGE */ 8) // NOLINT(clang-diagnostic-pointer-to-int-cast)
+        return true;
+
     return false;
-}
-
-extern "C" bool view3d_ima_drop_poll(void* c, void* drag, void* event)
-{
-    return BlenderPatcher::GetInstance()->View3DImaDropPoll(c, drag, event);
-}
-
-extern "C" void* ED_view3d_give_object_under_cursor(void* c, int mvals[2])
-{
-    return BlenderPatcher::GetInstance()->EDView3dGiveObjectUnderCursor(c, mvals);
 }

--- a/src/blender-injection/extern.h
+++ b/src/blender-injection/extern.h
@@ -5,6 +5,3 @@ extern "C" void DropEventHook(const char*, char*);
 
 extern "C" bool View3DImaEmptyDropPollHook(void*, void*, void*);
 
-extern "C" bool view3d_ima_drop_poll(void*, void*, void*);
-
-extern "C" void* ED_view3d_give_object_under_cursor(void*, int [2]);


### PR DESCRIPTION
This PR maybe resolves bugs related to Asset Browser.