### PR TITLE
fix for RuntimeError when load add-on artifacts that build by GitHub Actions

### DIFF
--- a/src/addon/__init__.py
+++ b/src/addon/__init__.py
@@ -32,7 +32,7 @@ else:
     from . import operator
     from . import preferences
 
-import bpy  # nopep8
+    import bpy  # nopep8
 
 
 classes: list[type] = [operator.DropEventListener, preferences.DragAndDropPreferences]


### PR DESCRIPTION
This maybe closes #76 