### PR TITLE
fix: Add Blender 5.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Blender add-on for importing some files from drag-and-drop.
 - `*.3mf` (Required [Blender 3MF Format](https://github.com/Ghostkeeper/Blender3mfFormat))
 - `*.abc`
 - `*.bvh`
-- `*.dae`
+- `*.dae` (Not supported in Blender 5.0+ due to Collada removal)
 - `*.fbx`
 - `*.glb`
 - `*.gltf`
@@ -76,6 +76,11 @@ v4.0.0 supports the following versions of Blender:
 - Blender 4.1.0
 - Blender 4.1.1
 - Blender 4.2.0 or greater
+
+v1.2.0 supports the following versions of Blender:
+
+- Blender 4.2.0 or greater
+- Blender 5.0 or greater (Note: Collada .dae format not supported due to removal in Blender 5.0)
 
 ## ScreenShot
 

--- a/src/addon/blender_manifest.toml
+++ b/src/addon/blender_manifest.toml
@@ -6,7 +6,7 @@ id = "drag_and_drop_support"
 maintainer = "Natsune Mochizuki <me@natsuneko.cat>"
 name = "Drag and Drop Support"
 tagline = "Support and improve drag and drop imports in Blender. "
-version = "1.1.0"
+version = "1.2.0"
 # Supported types: "add-on", "theme"
 type = "add-on"
 

--- a/src/addon/formats/dae.py
+++ b/src/addon/formats/dae.py
@@ -103,9 +103,12 @@ class VIEW3D_FH_Import_DAE(bpy.types.FileHandler):
         return context and context.area and context.area.type == "VIEW_3D"
 
 
-OPERATORS: list[type] = [
-    ImportDAEWithDefaults,
-    ImportDAEWithCustomSettings,
-    VIEW3D_MT_Space_Import_DAE,
-    VIEW3D_FH_Import_DAE,
-]
+# Only register DAE operators if Collada import is available (removed in Blender 5.0)
+OPERATORS: list[type] = []
+if hasattr(bpy.ops.wm, "collada_import"):
+    OPERATORS = [
+        ImportDAEWithDefaults,
+        ImportDAEWithCustomSettings,
+        VIEW3D_MT_Space_Import_DAE,
+        VIEW3D_FH_Import_DAE,
+    ]

--- a/src/addon/operator.py
+++ b/src/addon/operator.py
@@ -23,6 +23,7 @@ from .formats.super import VIEW3D_MT_Space_Import_BASE
 # formats that Blender does not supported by default
 conditionals: typing.Dict[str, typing.Callable[[], bool]] = {
     "3mf": lambda: hasattr(bpy.ops.import_mesh, "threemf"),
+    "dae": lambda: hasattr(bpy.ops.wm, "collada_import"),  # Removed in Blender 5.0
     "pmd": lambda: hasattr(bpy.ops, "mmd_tools"),
     "pmx": lambda: hasattr(bpy.ops, "mmd_tools"),
     "vmd": lambda: hasattr(bpy.ops, "mmd_tools"),


### PR DESCRIPTION
- Add version check to conditionally disable DAE support when Collada importer is not available (removed in Blender 5.0)
- Update operator to check for collada_import availability before processing DAE files
- Bump version to 1.2.0
- Update README to document DAE limitation in Blender 5.0+
- Add Blender 5.0 to supported versions list

This fixes compatibility issues with Blender 5.0 where the Collada (.dae) importer was removed.